### PR TITLE
Expand Travis deployment to create releases on tags

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,3 +8,10 @@ services:
 
 script:
   - docker-compose up -d
+
+deploy:
+  provider: releases
+  api_key: $GITHUB_OAUTH_TOKEN
+  skip_cleanup: true
+  on:
+    tags: true


### PR DESCRIPTION
GitHub releases are mandatory for the GitHub Zenodo integration in order to assign a Zenodo DOI